### PR TITLE
WIP: Add another exception to ignore

### DIFF
--- a/src/AllClasses.Desktop.cs
+++ b/src/AllClasses.Desktop.cs
@@ -65,6 +65,15 @@ namespace Unity.RegistrationByConvention
 
                 return new Assembly[0];
             }
+            catch (VerificationException)
+            {
+                if (!skipOnError)
+                {
+                    throw;
+                }
+
+                return new Assembly[0];
+            }
 
             return GetAssemblyNames(basePath, skipOnError)
                     .Select(an => LoadAssembly(Path.GetFileNameWithoutExtension(an), skipOnError))


### PR DESCRIPTION
I'm still investigating which dll is causing this, but we're getting the following exception when initialising our UnityContainer using this code

> System.Security.VerificationException: Operation could destabilize the runtime.
> at Unity.RegistrationByConvention.AllClasses.FromAssembliesInBasePath(Boolean includeSystemAssemblies, Boolean includeUnityAssemblies, Boolean skipOnError) in C:\projects\unity\RegistrationByConvention\src\AllClasses.Desktop.cs:line 48